### PR TITLE
Converter script for Elk DFT code

### DIFF
--- a/scripts/elk/.gitignore
+++ b/scripts/elk/.gitignore
@@ -1,0 +1,3 @@
+*.OUT
+RUNNING
+elk.in

--- a/scripts/elk/convert.py
+++ b/scripts/elk/convert.py
@@ -33,7 +33,7 @@ def get_energies_and_convert(lines, nx, ny, nz, startidx=13):
             break
     energies = np.array(energies)
     energies.resize((nx - 1, ny - 1, nz - 1))
-    energies *= 2  # Hartree to Rydberg
+    energies *= 2  # Hartree to Rydberg, assumes Fermi Energy is zero
     energies = energies.flatten()
     return energies, i + 1
 

--- a/scripts/elk/convert.py
+++ b/scripts/elk/convert.py
@@ -2,8 +2,10 @@ import sys
 from math import ceil
 import numpy as np
 
+
 def get_num_kpoints(lines):
     return [int(n) for n in lines[7].strip().split()]
+
 
 def get_kvecs_and_remove_2Pi(lines):
     kvecs = []
@@ -11,13 +13,16 @@ def get_kvecs_and_remove_2Pi(lines):
         kvecs.append([float(k) * 0.5 / np.pi for k in l.strip().split()])
     return kvecs
 
+
 def write_header(fin, fout, lines, nx, ny, nz, kvecs):
     fout.writelines(lines[:7])
     fout.write(' {} {} {}\n'.format(nx - 1, ny - 1, nz - 1))
     fout.writelines(lines[8:9])
     for kx, ky, kz in kvecs:
-        fout.write('     {0: 1.8f}     {1: 1.8f}     {2: 1.8f}\n'.format(kx, ky, kz))
+        fout.write(
+            '     {0: 1.8f}     {1: 1.8f}     {2: 1.8f}\n'.format(kx, ky, kz))
     fout.writelines(lines[12:13])
+
 
 def get_energies_and_convert(lines, nx, ny, nz, startidx=13):
     energies = []
@@ -28,20 +33,24 @@ def get_energies_and_convert(lines, nx, ny, nz, startidx=13):
             break
     energies = np.array(energies)
     energies.resize((nx - 1, ny - 1, nz - 1))
-    energies *= 2 #Hartree to Rydberg
+    energies *= 2  # Hartree to Rydberg
     energies = energies.flatten()
     return energies, i + 1
+
 
 def write_energies(fout, energies, entries_per_line=6):
     num_lines = ceil(len(energies) / entries_per_line)
     for i in range(num_lines):
         dnidx = i * entries_per_line
         upidx = min(len(energies), dnidx + entries_per_line)
-        elstr = ' ' + ' '.join(['{0: 1.6e}'.format(e) for e in energies[dnidx:upidx]])
+        elstr = ' ' + ' '.join(['{0: 1.6e}'.format(e)
+                               for e in energies[dnidx:upidx]])
         fout.write(elstr + '\n')
+
 
 def write_footer(fout, lines, endidx):
     fout.writelines(lines[endidx:])
+
 
 if __name__ == '__main__':
     if not 3 == len(sys.argv):

--- a/scripts/elk/convert.py
+++ b/scripts/elk/convert.py
@@ -1,0 +1,61 @@
+import sys
+from math import ceil
+import numpy as np
+
+def get_num_kpoints(lines):
+    return [int(n) for n in lines[7].strip().split()]
+
+def get_kvecs_and_remove_2Pi(lines):
+    kvecs = []
+    for l in lines[9:12]:
+        kvecs.append([float(k) * 0.5 / np.pi for k in l.strip().split()])
+    return kvecs
+
+def write_header(fin, fout, lines, nx, ny, nz, kvecs):
+    fout.writelines(lines[:7])
+    fout.write(' {} {} {}\n'.format(nx, ny, nz))
+    fout.writelines(lines[8:9])
+    for kx, ky, kz in kvecs:
+        fout.write('     {0: 1.8f}     {1: 1.8f}     {2: 1.8f}\n'.format(kx, ky, kz))
+    fout.writelines(lines[12:13])
+
+def get_energies_and_convert(lines, nx, ny, nz):
+    energies = []
+    ntot = nx * ny * nz
+    startidx = 13
+    for i, l in enumerate(lines[startidx:], startidx):
+        energies += [float(e) for e in l.strip().split()]
+        if len(energies) >= ntot:
+            break
+    energies = np.array(energies)
+    energies.resize((nx - 1, ny - 1, nz - 1))
+    energies *= 2 #Hartree to Rydberg
+    energies = energies.flatten()
+    return energies, i + 1
+
+def write_energies(fout, energies, entries_per_line=6):
+    num_lines = ceil(len(energies) / entries_per_line)
+    for i in range(num_lines):
+        dnidx = i * entries_per_line
+        upidx = min(len(energies), dnidx + entries_per_line)
+        elstr = ' ' + ' '.join(['{0: 1.6e}'.format(e) for e in energies[dnidx:upidx]])
+        fout.write(elstr + '\n')
+
+def write_footer(fout, lines, endidx):
+    fout.writelines(lines[endidx:])
+
+if __name__ == '__main__':
+    if not 3 == len(sys.argv):
+        raise Exception('Please supply input and output file names.')
+    infilename = sys.argv[1]
+    outfilename = sys.argv[2]
+
+    with open(infilename, 'rt') as fin:
+        with open(outfilename, 'wt') as fout:
+            lines = fin.readlines()
+            nx, ny, nz = get_num_kpoints(lines)
+            kvecs = get_kvecs_and_remove_2Pi(lines)
+            write_header(fin, fout, lines, nx, ny, nz, kvecs)
+            energies, endidx = get_energies_and_convert(lines, nx, ny, nz)
+            write_energies(fout, energies)
+            write_footer(fout, lines, endidx)

--- a/scripts/elk/convert.py
+++ b/scripts/elk/convert.py
@@ -16,7 +16,7 @@ def get_kvecs_and_remove_2Pi(lines):
 
 def write_header(fin, fout, lines, nx, ny, nz, kvecs):
     fout.writelines(lines[:7])
-    fout.write(' {} {} {}\n'.format(nx - 1, ny - 1, nz - 1))
+    fout.write(' {} {} {}\n'.format(nx, ny, nz))
     fout.writelines(lines[8:9])
     for kx, ky, kz in kvecs:
         fout.write(
@@ -32,9 +32,7 @@ def get_energies_and_convert(lines, nx, ny, nz, startidx=13):
         if len(energies) >= ntot:
             break
     energies = np.array(energies)
-    energies.resize((nx - 1, ny - 1, nz - 1))
     energies *= 2  # Hartree to Rydberg, assumes Fermi Energy is zero
-    energies = energies.flatten()
     return energies, i + 1
 
 

--- a/scripts/elk/convert.py
+++ b/scripts/elk/convert.py
@@ -13,7 +13,7 @@ def get_kvecs_and_remove_2Pi(lines):
 
 def write_header(fin, fout, lines, nx, ny, nz, kvecs):
     fout.writelines(lines[:7])
-    fout.write(' {} {} {}\n'.format(nx, ny, nz))
+    fout.write(' {} {} {}\n'.format(nx - 1, ny - 1, nz - 1))
     fout.writelines(lines[8:9])
     for kx, ky, kz in kvecs:
         fout.write('     {0: 1.8f}     {1: 1.8f}     {2: 1.8f}\n'.format(kx, ky, kz))

--- a/scripts/elk/convert.py
+++ b/scripts/elk/convert.py
@@ -29,7 +29,8 @@ def write_header(fout, lines, kvecs):
     for kx, ky, kz in kvecs:
         fout.write(
             '     {0: 1.8f}     {1: 1.8f}     {2: 1.8f}\n'.format(kx, ky, kz))
-    fout.writelines(lines[12:13])
+    i += 3
+    fout.writelines(lines[i:i+1])
 
 
 def get_energies_and_convert(lines, nx, ny, nz):

--- a/scripts/elk/convert.py
+++ b/scripts/elk/convert.py
@@ -2,15 +2,18 @@ import sys
 from math import ceil
 import numpy as np
 
+
 def find_bandgrid_3d_bands(lines):
     for i, l in enumerate(lines):
         if 'BANDGRID_3D_BANDS' in l:
             return i
     raise Exception('BANDGRID_3D_BANDS not found.')
 
+
 def get_num_kpoints(lines):
     i = find_bandgrid_3d_bands(lines) + 2
     return [int(n) for n in lines[i].strip().split()]
+
 
 def get_kvecs_and_remove_2Pi(lines):
     i = find_bandgrid_3d_bands(lines) + 4

--- a/scripts/elk/convert.py
+++ b/scripts/elk/convert.py
@@ -19,10 +19,9 @@ def write_header(fin, fout, lines, nx, ny, nz, kvecs):
         fout.write('     {0: 1.8f}     {1: 1.8f}     {2: 1.8f}\n'.format(kx, ky, kz))
     fout.writelines(lines[12:13])
 
-def get_energies_and_convert(lines, nx, ny, nz):
+def get_energies_and_convert(lines, nx, ny, nz, startidx=13):
     energies = []
     ntot = nx * ny * nz
-    startidx = 13
     for i, l in enumerate(lines[startidx:], startidx):
         energies += [float(e) for e in l.strip().split()]
         if len(energies) >= ntot:


### PR DESCRIPTION
Added a converter script for BXSF files generate from the Elk DFT code.

This script performs the following operations:

- Convert energies from Hartree to Rydberg
- Remove factor of 2*PI from reciprocal lattice vectors